### PR TITLE
Add EEPROM support for persistent tuning

### DIFF
--- a/software/CLMC/CLMC.ino
+++ b/software/CLMC/CLMC.ino
@@ -90,7 +90,7 @@ void loop() {
         Serial.println("No tuning mode currently set.");
       }
     } else if (s == 't') { //Set controller to tune.
-      delay(50);//Wait for second character to arrive.
+      serial_wait_timeout(1, 20);
       char a = Serial.read();
       Serial.println(a);
       if (a == 'p') {
@@ -167,7 +167,17 @@ void loop() {
   if (control) command_motor(get_pid_output());
 
 }
-
+/**
+ * Waits for serial bytes, or timeout, whichever comes first.
+ * len: number of bytes to wait for.
+ * timeout: timeout in ms to wait for bytes.
+ * Returns nothing.
+ */
+void serial_wait_timeout(int len, int timeout){
+  long start_t = millis();
+  while(Serial.available() < len && millis() < timeout + start_t);
+  Serial.print("Waited: "); Serial.println(millis() - start_t);
+}
 bool get_control() {
   return control;
 }

--- a/software/CLMC/CLMC.ino
+++ b/software/CLMC/CLMC.ino
@@ -22,7 +22,7 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
 //Uncomment to load config and PIDs from EEPROM on boot.
-//#define LOAD_CONFIG_ON_BOOT
+#define LOAD_CONFIG_ON_BOOT
 
 //Serial baud rate
 #define BAUD_RATE 9600
@@ -51,9 +51,9 @@ void setup() {
     digitalWrite(LED_PIN, LOW);
     delay(100);
   }
-  #ifdef LOAD_CONFIG_ON_BOOT
+#ifdef LOAD_CONFIG_ON_BOOT
   load_config();
-  #endif
+#endif
 }
 
 //Flag for enabling motor output.
@@ -90,13 +90,16 @@ void loop() {
         Serial.println("No tuning mode currently set.");
       }
     } else if (s == 't') { //Set controller to tune.
-      if (s == 'p') {
+      delay(50);//Wait for second character to arrive.
+      char a = Serial.read();
+      Serial.println(a);
+      if (a == 'p') {
         Serial.println("Selecting position controller");
         set_tune_mode(TUNE_POS);
-      } else if (s == 'v') {
+      } else if (a == 'v') {
         Serial.println("Selecting velocity controller");
         set_tune_mode(TUNE_VEL);
-      } else if (s == 'a') {
+      } else if (a == 'a') {
         Serial.println("Selecting acceleration controller");
         set_tune_mode(TUNE_ACC);
       } else {
@@ -105,14 +108,18 @@ void loop() {
       }
     } else if (s == 'j') {
       set_inst_vel_filter(Serial.parseFloat());
-    } else if (s == 'l'){
+    } else if (s == 'l') {
       Serial.println("Loading config from EEPROM");
       load_config();
-    } else if (s == 's'){
+    } else if (s == 'k') {
       Serial.println("Saving config to EEPROM");
       save_config();
+    } else if (s == 'z') {
+      print_pids();
+    } else if (s == 'x') {
+      print_EEPROM();
     } else if (s == 'h') {
-      Serial.println("**** Commands ****");
+      Serial.println("\n**** Commands ****");
       Serial.println("r<int>\tConstant Position");
       Serial.println("f<int>\tConstant Velocity");
       Serial.println("v<float>\tConstant Acceleration");
@@ -123,12 +130,13 @@ void loop() {
       Serial.println("i<float>\tSet I component of tuned controller");
       Serial.println("d<float>\tSet D component of tuned controller");
       Serial.println("j<float>\tSet strength of velocity particle filter");
-      Serial.println("s\tSave configuration to EEPROM");
+      Serial.println("z\tPrint PID values");
+      Serial.println("x\tPrint EEPROM values");
+      Serial.println("k\tSave configuration to EEPROM");
       Serial.println("l\tLoad configuration from EEPROM");
       Serial.println("h\tShow help menu");
     }
   }
-
 
 
   //Diagnostic output:
@@ -138,9 +146,9 @@ void loop() {
   Serial.print("\tInst_acc: ");
   Serial.print(get_inst_acceleration());
 
-  if(get_tune_mode() == TUNE_POS){
-  Serial.print("\tAbs_pos: ");
-  Serial.print(get_raw_count());
+  if (get_tune_mode() == TUNE_POS) {
+    Serial.print("\tAbs_pos: ");
+    Serial.print(get_raw_count());
   }
   //Setpoints
   Serial.print("\tPos_set: ");
@@ -160,10 +168,10 @@ void loop() {
 
 }
 
-bool get_control(){
+bool get_control() {
   return control;
 }
 
-void set_control(bool val){
+void set_control(bool val) {
   control = val;
 }

--- a/software/CLMC/CLMC.ino
+++ b/software/CLMC/CLMC.ino
@@ -21,12 +21,8 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
-//Uncomment the #define for the channel that is currently being tuned
-//This binds the p, i, and d commands to that channel.
-//Also outputs absolute position if position mode is selected.
-#define TUNE_POS
-//#define TUNE_VEL
-//#define TUNE_ACC
+//Uncomment to load config and PIDs from EEPROM on boot.
+//#define LOAD_CONFIG_ON_BOOT
 
 //Serial baud rate
 #define BAUD_RATE 9600
@@ -35,6 +31,11 @@
 #define LED_PIN 13
 
 
+
+#define TUNE_NONE 0
+#define TUNE_POS 1
+#define TUNE_VEL 2
+#define TUNE_ACC 3
 void setup() {
 
   Serial.begin(BAUD_RATE);
@@ -50,7 +51,9 @@ void setup() {
     digitalWrite(LED_PIN, LOW);
     delay(100);
   }
-
+  #ifdef LOAD_CONFIG_ON_BOOT
+  load_config();
+  #endif
 }
 
 //Flag for enabling motor output.
@@ -78,18 +81,51 @@ void loop() {
       tune_i(Serial.parseFloat());
     } else if (s == 'd') {
       tune_d(Serial.parseFloat());
-    } else if (s == 't') {
-#if defined (TUNE_POS) || defined (TUNE_VEL)
-      command_tune(Serial.parseInt());
-#else
-#if defined (TUNE_ACC)
-      command_tune(Serial.parseFloat());
-#else
-      Serial.println("No tuning mode currently set.");
-#endif
-#endif
+    } else if (s == 's') {
+      if (get_tune_mode() == TUNE_POS || get_tune_mode() == TUNE_VEL) {
+        command_tune(Serial.parseInt());
+      } else if (get_tune_mode() == TUNE_ACC) {
+        command_tune(Serial.parseFloat());
+      } else {
+        Serial.println("No tuning mode currently set.");
+      }
+    } else if (s == 't') { //Set controller to tune.
+      if (s == 'p') {
+        Serial.println("Selecting position controller");
+        set_tune_mode(TUNE_POS);
+      } else if (s == 'v') {
+        Serial.println("Selecting velocity controller");
+        set_tune_mode(TUNE_VEL);
+      } else if (s == 'a') {
+        Serial.println("Selecting acceleration controller");
+        set_tune_mode(TUNE_ACC);
+      } else {
+        Serial.println("Deselecting tuned controller");
+        set_tune_mode(TUNE_NONE);
+      }
     } else if (s == 'j') {
       set_inst_vel_filter(Serial.parseFloat());
+    } else if (s == 'l'){
+      Serial.println("Loading config from EEPROM");
+      load_config();
+    } else if (s == 's'){
+      Serial.println("Saving config to EEPROM");
+      save_config();
+    } else if (s == 'h') {
+      Serial.println("**** Commands ****");
+      Serial.println("r<int>\tConstant Position");
+      Serial.println("f<int>\tConstant Velocity");
+      Serial.println("v<float>\tConstant Acceleration");
+      Serial.println("e\tEnable Output");
+      Serial.println("w<int>\tDisable Output");
+      Serial.println("t[p,v,a]\tSelect controller to tune");
+      Serial.println("p<float>\tSet P component of tuned controller");
+      Serial.println("i<float>\tSet I component of tuned controller");
+      Serial.println("d<float>\tSet D component of tuned controller");
+      Serial.println("j<float>\tSet strength of velocity particle filter");
+      Serial.println("s\tSave configuration to EEPROM");
+      Serial.println("l\tLoad configuration from EEPROM");
+      Serial.println("h\tShow help menu");
     }
   }
 
@@ -102,10 +138,10 @@ void loop() {
   Serial.print("\tInst_acc: ");
   Serial.print(get_inst_acceleration());
 
-#ifdef TUNE_POS
+  if(get_tune_mode() == TUNE_POS){
   Serial.print("\tAbs_pos: ");
   Serial.print(get_raw_count());
-#endif
+  }
   //Setpoints
   Serial.print("\tPos_set: ");
   Serial.print(get_pos_setpoint());
@@ -122,4 +158,12 @@ void loop() {
   update_pid();
   if (control) command_motor(get_pid_output());
 
+}
+
+bool get_control(){
+  return control;
+}
+
+void set_control(bool val){
+  control = val;
 }

--- a/software/CLMC/EEPROM_Interface.h
+++ b/software/CLMC/EEPROM_Interface.h
@@ -1,0 +1,23 @@
+/**
+ * File: EEPROM_Interface.h
+ * Author: Lukas Severinghaus
+ * Date: November 16, 2020
+ * Purpose: Header file for EEPROM interface.
+ * 
+ * License:
+ * Copyright (C) 2020  Lukas Severinghaus
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3
+ * as published by the Free Software Foundation; 
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+struct CLMC_Config get_config();

--- a/software/CLMC/EEPROM_Interface.ino
+++ b/software/CLMC/EEPROM_Interface.ino
@@ -93,10 +93,20 @@ void set_config(CLMC_Config c){
 void load_config(){
   CLMC_Config c;
   EEPROM.get(config_address, c);
+  if(c.id == EEPROM_KEY){
   set_config(c); 
+  }else{
+    Serial.println("Error: EEPROM did not verify");
+  }
 }
 
 void save_config(){
   CLMC_Config c = get_config();
   EEPROM.put(config_address, c);
+}
+
+void print_EEPROM(){
+  CLMC_Config c;
+  EEPROM.get(config_address, c);
+  Serial.print("ID: "); Serial.println(c.id);
 }

--- a/software/CLMC/EEPROM_Interface.ino
+++ b/software/CLMC/EEPROM_Interface.ino
@@ -1,0 +1,102 @@
+/**
+ * File: EEPROM_Interface.ino
+ * Author: Lukas Severinghaus
+ * Date: November 16, 2020
+ * Purpose: Handles interfacing with onboard EEPROM.
+ * 
+ * License:
+ * Copyright (C) 2020  Lukas Severinghaus
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License version 3
+ * as published by the Free Software Foundation; 
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+ /**
+  * Resources used during development:
+  * Arduino EEPROM Library Reference:
+  *   https://www.arduino.cc/en/Reference/EEPROMPut
+  *   https://www.arduino.cc/en/Reference/EEPROMGet
+  */
+#include <EEPROM.h>
+const int config_address = 0;
+#define EEPROM_KEY 0x11 //ID used to verify the config. Changing this value forces a new config to be created.
+struct CLMC_Config {
+  byte id = EEPROM_KEY;//ID to identify this as a config.
+  float pos_p;
+  float pos_i;
+  float pos_d;
+
+  float vel_p;
+  float vel_i;
+  float vel_d;
+
+  float acc_p;
+  float acc_i;
+  float acc_d;
+
+  byte PID_state;//Currently activated mode for PID manager
+  byte tune_mode;//Currently selected controller for tuning
+  bool enable_output;
+};
+
+struct CLMC_Config get_config(){
+  CLMC_Config out;
+  out.pos_p = pos_p();
+  out.pos_i = pos_i();
+  out.pos_d = pos_d();
+
+  out.vel_p = vel_p();
+  out.vel_i = vel_i();
+  out.vel_d = vel_d();
+
+  out.acc_p = acc_p();
+  out.acc_i = acc_i();
+  out.acc_d = acc_d();
+
+  out.PID_state = get_PID_current_state();
+  out.tune_mode = get_tune_mode();//Not used right now.
+  out.enable_output = get_control();
+  return out;
+}
+
+void set_config(CLMC_Config c){
+  if(c.id == EEPROM_KEY){
+  pos_p(c.pos_p);
+  pos_i(c.pos_i);
+  pos_d(c.pos_d);
+
+  vel_p(c.vel_p);
+  vel_i(c.vel_i);
+  vel_d(c.vel_d);
+
+  acc_p(c.acc_p);
+  acc_i(c.acc_i);
+  acc_d(c.acc_d);
+
+  set_tune_mode(c.tune_mode);
+  set_PID_current_state(c.PID_state);
+  set_control(c.enable_output);
+  }else{
+    Serial.println("No existing EEPROM config found with matching id.");
+  }
+}
+
+void load_config(){
+  CLMC_Config c;
+  EEPROM.get(config_address, c);
+  set_config(c); 
+}
+
+void save_config(){
+  CLMC_Config c = get_config();
+  EEPROM.put(config_address, c);
+}

--- a/software/CLMC/PID_Manager.ino
+++ b/software/CLMC/PID_Manager.ino
@@ -300,3 +300,22 @@ byte get_tune_mode() {
 void set_tune_mode(byte b) {
   tune_mode = b;
 }
+
+void print_pids(){
+  Serial.println("**** PID Values ****");
+  Serial.println("Position: ");
+  Serial.print("\tP:"); Serial.println(pos_kp);
+  Serial.print("\tI:"); Serial.println(pos_ki);  
+  Serial.print("\tD:"); Serial.println(pos_kd);
+  Serial.println("");
+  Serial.println("Velocity: ");
+  Serial.print("\tP:"); Serial.println(vel_kp);
+  Serial.print("\tI:"); Serial.println(vel_ki);  
+  Serial.print("\tD:"); Serial.println(vel_kd);
+  Serial.println("");
+  Serial.println("Acceleration: ");
+  Serial.print("\tP:"); Serial.println(acc_kp);
+  Serial.print("\tI:"); Serial.println(acc_ki);  
+  Serial.print("\tD:"); Serial.println(acc_kd);
+  Serial.println("**** End PID Values ****");  
+}


### PR DESCRIPTION
This branch adds several new and important features:
* Improved serial interface
  * Added serial help menu
  * Added command to print PID values
* EEPROM persistence
  * Load configuration from EEPROM
  * Save current configuration from EEPROM
Configuration includes PIDs from all three controllers, current tuning mode, output control, and currently activated controller.

Some future changes the came up during development:
There needs to be better management of the serial interface:
* Add flag to disable all plain text error messages
* Add machine readable interface and command structure
* Add flag to switch between human and machine command structure
* Add flag to enable/disable position output for plotting